### PR TITLE
fix: corrige tamanhos menores de estilos

### DIFF
--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -38,7 +38,8 @@ const ButtonDefault = css<iButtonType & iButtonSize>`
       case 'lg-min':
         return css`
           height: 4.0625rem;
-          padding: 0 1.5rem;
+          padding: 0 3.5rem;
+          width: max-content;
           font-size: var(--font-size-2);
           line-height: var(--line-height-1);
         `;
@@ -47,7 +48,7 @@ const ButtonDefault = css<iButtonType & iButtonSize>`
         return css`
           width: 100%;
           height: 4.0625rem;
-          padding: 0 1.5rem;
+          padding: 0 3.5rem;
           font-size: var(--font-size-2);
           line-height: var(--line-height-1);
         `;
@@ -55,7 +56,8 @@ const ButtonDefault = css<iButtonType & iButtonSize>`
       case 'md-min':
         return css`
           height: 3.4375rem;
-          padding: 0 1.25rem;
+          padding: 0 2.25rem;
+          width: max-content;
           font-size: var(--font-size-1);
           line-height: var(--line-height-0);
         `;
@@ -64,7 +66,7 @@ const ButtonDefault = css<iButtonType & iButtonSize>`
         return css`
           width: 100%;
           height: 3.4375rem;
-          padding: 0 1.25rem;
+          padding: 0 2.25rem;
           font-size: var(--font-size-1);
           line-height: var(--line-height-0);
         `;
@@ -73,6 +75,7 @@ const ButtonDefault = css<iButtonType & iButtonSize>`
         return css`
           height: 2.8125rem;
           padding: 0 1rem;
+          width: max-content;
           font-size: var(--font-size-0);
           line-height: var(--line-height-0);
         `;
@@ -93,6 +96,6 @@ export const StyledButton = styled.button`
   ${ButtonDefault}
 `;
 
-export const StyledLink = styled(Link)`
+export const StyledButtonLink = styled(Link)`
   ${ButtonDefault}
 `;

--- a/src/styles/inputs.ts
+++ b/src/styles/inputs.ts
@@ -1,10 +1,10 @@
 import styled, { css } from 'styled-components';
 
-interface iInputSize {
+export interface iInputSize {
   inputSize: 'md-min' | 'md-max' | 'lg-min' | 'lg-max';
 }
 
-interface iInputStyle {
+export interface iInputStyle {
   inputStyle: 'default' | 'borderless';
 }
 
@@ -38,6 +38,8 @@ const InputSettings = css<iInputSize & iInputStyle>`
         return css`
           font-size: var(--font-size-3);
           line-height: var(--line-height-3);
+          width: 100%;
+          max-width: 23.125rem;
 
           &::placeholder {
             color: var(--color-input-default);
@@ -62,6 +64,8 @@ const InputSettings = css<iInputSize & iInputStyle>`
         return css`
           font-size: var(--font-size-4);
           line-height: var(--line-height-3);
+          width: 100%;
+          max-width: 23.125rem;
 
           &::placeholder {
             color: var(--color-input-default);

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,17 +1,14 @@
+import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-
-const defaultSettingsTitle = css`
-  font-family: var(--font-family);
-  font-weight: var(--font-weight-0);
-  color: var(--color-black);
-`;
 
 interface iSettingsTitle {
   fontStyle: 'lg' | 'md' | 'sm' | 'm-lg' | 'm-md' | 'post' | 'm-post';
 }
 
-export const StyledTitle = styled.h1`
-  ${defaultSettingsTitle}
+const defaultSettingsTitle = css`
+  font-family: var(--font-family);
+  font-weight: var(--font-weight-0);
+  color: var(--color-black);
 
   ${({ fontStyle }: iSettingsTitle) => {
     switch (fontStyle) {
@@ -60,6 +57,22 @@ export const StyledTitle = styled.h1`
   }}
 `;
 
+export const StyledTitleOne = styled.h1`
+  ${defaultSettingsTitle}
+`;
+
+export const StyledTitleTwo = styled.h2`
+  ${defaultSettingsTitle}
+`;
+
+export const StyledTitleThree = styled.h3`
+  ${defaultSettingsTitle}
+`;
+
+export const StyledTitleFour = styled.h4`
+  ${defaultSettingsTitle}
+`;
+
 const defaultSettingsParagraph = css`
   font-family: var(--font-family-secondary);
   font-weight: var(--font-weight-0);
@@ -99,12 +112,12 @@ export const StyledParagraph = styled.p`
 export const StyledLabel = styled.label`
   font-family: var(--font-family-secondary);
   font-size: var(--font-size-0);
-  font-weight: var(--font-weight-0);
+  font-weight: var(--font-weight-1);
   line-height: var(--line-height-0);
   color: var(--color-black);
 `;
 
-export const StyledLink = styled.label`
+export const StyledLink = styled(Link)`
   font-family: var(--font-family-secondary);
   font-size: var(--font-size-1);
   font-weight: var(--font-weight-0);


### PR DESCRIPTION
- Corrige os tamanhos menos que não estavam pegando de Inputs e buttons.

- No caso da typografia, havia um erro de semântica de HTML durante a criação do arquivo typography default. Apenas existia um h1 para todo o projeto. Foi corrigido e adicionado h1, h2, h3 e h4.