### PR TITLE
style: cria form e header da Editing Notice Page

### DIFF
--- a/src/assets/icons/left-arrow.svg
+++ b/src/assets/icons/left-arrow.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill-rule="evenodd" clip-rule="evenodd" d="M11.7071 4.29289C12.0976 4.68342 12.0976 5.31658 11.7071 5.70711L6.41421 11H20C20.5523 11 21 11.4477 21 12C21 12.5523 20.5523 13 20 13H6.41421L11.7071 18.2929C12.0976 18.6834 12.0976 19.3166 11.7071 19.7071C11.3166 20.0976 10.6834 20.0976 10.2929 19.7071L3.29289 12.7071C3.10536 12.5196 3 12.2652 3 12C3 11.7348 3.10536 11.4804 3.29289 11.2929L10.2929 4.29289C10.6834 3.90237 11.3166 3.90237 11.7071 4.29289Z" fill="#55A3FF"/> </g>
+</svg>

--- a/src/components/structures/EditingNotice/Form/index.tsx
+++ b/src/components/structures/EditingNotice/Form/index.tsx
@@ -1,0 +1,26 @@
+import { StyledButton } from "../../../../styles/buttons";
+import { InputLabel } from "../../../fragments/InputLabel";
+import { TextareaLabel } from "../../../fragments/TextareaLabel";
+import { StyledEditingFormContainer } from "./style";
+
+export const EditingNoticeForm = () => {
+  return (
+    <StyledEditingFormContainer>
+      <InputLabel label='Título' inputSize='md-max' inputStyle='borderless' />
+      <InputLabel
+        label='Imagem em destaque'
+        inputSize='md-max'
+        inputStyle='borderless'
+      />
+      <TextareaLabel
+        label='Conteúdo'
+        rows={11}
+        inputSize='md-max'
+        inputStyle='borderless'
+      />
+      <StyledButton buttonSize='md-min' buttonType='primary'>
+        Salvar post
+      </StyledButton>
+    </StyledEditingFormContainer>
+  );
+};

--- a/src/components/structures/EditingNotice/Form/style.ts
+++ b/src/components/structures/EditingNotice/Form/style.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const StyledEditingFormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 57.5rem;
+  gap: 1.25rem;
+
+  > button {
+    margin-top: 1.25rem;
+  }
+`;

--- a/src/components/structures/Header/index.tsx
+++ b/src/components/structures/Header/index.tsx
@@ -1,0 +1,21 @@
+import LeftArrowIcon from '../../../../../src/assets/icons/left-arrow.svg'
+import { StyledButtonLink } from "../../../../styles/buttons";
+import { StyledTitleOne, StyledParagraph } from "../../../../styles/typography";
+import { StyledEditingHeaderContainer } from "./style";
+
+export const EditingNoticeHeader = () => {
+  return (
+    <StyledEditingHeaderContainer>
+      <StyledTitleOne fontStyle='md'>Editando:</StyledTitleOne>
+      <StyledButtonLink buttonSize='sm-min' buttonType='outline' to='/'>
+        <figure>
+          <img
+            src={LeftArrowIcon}
+            alt='seta para esquerda voltar pagina anterior'
+          />
+          <StyledParagraph fontStyle='lg'>Voltar</StyledParagraph>
+        </figure>
+      </StyledButtonLink>
+    </StyledEditingHeaderContainer>
+  );
+};

--- a/src/components/structures/Header/style.ts
+++ b/src/components/structures/Header/style.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const StyledEditingHeaderContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 57.5rem;
+
+  figure {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.625rem;
+  }
+
+  figure > img {
+    width: 1.5625rem;
+  }
+
+  figure > p {
+    color: var(--color-primary);
+  }
+`;


### PR DESCRIPTION
Cria a estilização do formulário de edição e também cria o header desse formulário de forma separada. Já que o mesmo só é usado para redirecionar para a pagina anterior.